### PR TITLE
Synchronize fan_mode from the main thermostat to the Aqara, and handle "med" vs "medium"

### DIFF
--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -178,13 +178,12 @@ actions:
                   {% set source = state_attr(main_thermostat, "fan_mode") %}
                   {% set target = state_attr(aqara_w100, "fan_mode") %}
 
-                  {# Normalize both to lowercase and map med->medium for comparison #}
-                  {% set source_norm = source | lower | replace('med', 'medium') %}
-                  {% set target_norm = target | lower | replace('med', 'medium') %}
+                  {# Normalize the source to lowercase and map med->medium for comparison #}
+                  {% set source_norm = 'medium' if source | lower == 'med' else source | lower %}
 
                   {# Compare normalized values #}
                   {{ 
-                    (source_norm != target_norm) and 
+                    (source_norm != target) and 
                     (hvac_has_vent | default(false) | bool) 
                   }}
             then:
@@ -273,13 +272,12 @@ actions:
                   {% set source = state_attr(main_thermostat, "fan_mode") %}
                   {% set target = state_attr(aqara_w100, "fan_mode") %}
 
-                  {# Normalize both to lowercase and map med->medium for comparison #}
-                  {% set source_norm = source | lower | replace('med', 'medium') %}
-                  {% set target_norm = target | lower | replace('med', 'medium') %}
+                  {# Normalize source to lowercase and map med->medium for comparison #}
+                  {% set source_norm = 'medium' if source | lower == 'med' else source | lower %}
 
                   {# Compare normalized values #}
                   {{ 
-                    (source_norm != target_norm) and 
+                    (source_norm != target) and 
                     (hvac_has_vent | default(false) | bool) 
                   }}
             then:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -174,10 +174,18 @@ actions:
           - if:
               - condition: template
                 value_template: >
-                  {{
-                  (state_attr(main_thermostat, "fan_mode") !=
-                  state_attr(aqara_w100, "fan_mode")) and
-                  (hvac_has_vent | default(false) | bool)
+                  {# Define the variables#}
+                  {% set source = state_attr(main_thermostat, "fan_mode") %}
+                  {% set target = state_attr(aqara_w100, "fan_mode") %}
+
+                  {# Normalize both to lowercase and map med->medium for comparison #}
+                  {% set source_norm = source | lower | replace('med', 'medium') %}
+                  {% set target_norm = target | lower | replace('med', 'medium') %}
+
+                  {# Compare normalized values #}
+                  {{ 
+                    (source_norm != target_norm) and 
+                    (hvac_has_vent | default(false) | bool) 
                   }}
             then:
               - action: climate.set_fan_mode
@@ -185,7 +193,15 @@ actions:
                   entity_id: !input aqara_w100
                 data:
                   fan_mode: |
-                    {{ state_attr(main_thermostat, "fan_mode") }}
+                    {% set source = state_attr(main_thermostat, "fan_mode") %}
+
+                    {# If source is med/medium, pass "medium" to the Aqara #}
+                    {% if source | lower == 'med' or source | lower == 'medium' %}
+                      medium
+                    {# Otherwise just pass the source through #}
+                    {% else %}
+                      {{ source }}
+                    {% endif %}
               - delay:
                   seconds: "{{ sync_delay }}"
       - conditions:
@@ -253,10 +269,18 @@ actions:
           - if:
               - condition: template
                 value_template: >
-                  {{
-                  (state_attr(main_thermostat, "fan_mode") !=
-                  state_attr(aqara_w100, "fan_mode")) and
-                  (hvac_has_vent | default(false) | bool)
+                  {# Define the variables#}
+                  {% set source = state_attr(main_thermostat, "fan_mode") %}
+                  {% set target = state_attr(aqara_w100, "fan_mode") %}
+
+                  {# Normalize both to lowercase and map med->medium for comparison #}
+                  {% set source_norm = source | lower | replace('med', 'medium') %}
+                  {% set target_norm = target | lower | replace('med', 'medium') %}
+
+                  {# Compare normalized values #}
+                  {{ 
+                    (source_norm != target_norm) and 
+                    (hvac_has_vent | default(false) | bool) 
                   }}
             then:
               - action: climate.set_fan_mode
@@ -264,7 +288,17 @@ actions:
                   entity_id: !input main_thermostat
                 data:
                   fan_mode: |
-                    {{ state_attr(aqara_w100, "fan_mode") }}
+                    {% set source = state_attr(aqara_w100, "fan_mode") %}
+                    {% set target_valid_list = state_attr(main_thermostat, "fan_modes") %}
+
+                    {# If source is med/medium, find the target's specific medium mode #}
+                    {% if source | lower == 'med' or source | lower == 'medium' %}
+                      {{ target_valid_list | select('search', '(?i)^med') | first | default(source) }}
+
+                    {# Otherwise just pass the source through #}
+                    {% else %}
+                      {{ source }}
+                    {% endif %}
               - delay:
                   seconds: "{{ sync_delay }}"
       - conditions:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -171,6 +171,23 @@ actions:
                     {{ state_attr(main_thermostat, "temperature") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+          - if:
+              - condition: template
+                value_template: >
+                  {{
+                  (state_attr(main_thermostat, "fan_mode") !=
+                  state_attr(aqara_w100, "fan_mode")) and
+                  (hvac_has_vent | default(false) | bool)
+                  }}
+            then:
+              - action: climate.set_fan_mode
+                target:
+                  entity_id: !input aqara_w100
+                data:
+                  fan_mode: |
+                    {{ state_attr(main_thermostat, "fan_mode") }}
+              - delay:
+                  seconds: "{{ sync_delay }}"
       - conditions:
           - condition: trigger
             id:


### PR DESCRIPTION
This pull request contains 2 changes.

1. I've added a block in the sync from the main thermostat to the Aqara W100 to synchronize the fan_mode.
2. My main thermostat uses "med" whereas the Aqara W100 uses "medium" for the fan_mode between "low" and "high". I've added normalization so the automation doesn't think that the 2 climate entities are set at different fan modes, and the automation will send "med" or "medium" to the main thermostat depending on which one appears in that entity's fan_modes.