### PR TITLE
Refactor: Auto-derive W100 external sensors and mode switch from aqara_w100 + simplify inputs and fix HVAC sync logic

### DIFF
--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -6,7 +6,6 @@ blueprint:
     Optionally publishes external temperature and humidity data to the W100 display.
     Configure which HVAC modes and features your system supports.
   domain: automation
-  
   input:
     main_thermostat:
       name: Main Thermostat
@@ -88,7 +87,7 @@ variables:
   enable_external_data: !input enable_external_data
   external_temperature_sensor: !input external_temperature_sensor
   external_humidity_sensor: !input external_humidity_sensor
-  thermostat_mode_switch: >-
+  w100_thermostat_mode: >-
     {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
 
 triggers:
@@ -115,17 +114,19 @@ actions:
           - condition: trigger
             id:
               - climate_state
-          - condition: template
-            value_template: >-
-              {{ is_state(thermostat_mode_switch, 'on') }}
+          - condition: state
+            entity_id: !input w100_thermostat_mode
+            state:
+              - "on"
         sequence:
           - if:
               - condition: template
                 value_template: >-
                   {{ states(main_thermostat) != states(aqara_w100) }}
-              - condition: template
-                value_template: >-
-                  {{ is_state(thermostat_mode_switch, 'on') }}
+              - condition: state
+                entity_id: !input w100_thermostat_mode
+                state:
+                  - "on"
             then:
               - action: climate.set_hvac_mode
                 target:
@@ -149,14 +150,14 @@ actions:
                     {{ state_attr(main_thermostat, "temperature") }}
               - delay:
                   seconds: "{{ sync_delay }}"
-      
       - conditions:
           - condition: trigger
             id:
               - w100_climate_state
-          - condition: template
-            value_template: >-
-              {{ is_state(thermostat_mode_switch, 'on') }}
+          - condition: state
+            entity_id: !input w100_thermostat_mode
+            state:
+              - "on"
         sequence:
           - if:
               - condition: template
@@ -228,7 +229,6 @@ actions:
                     {{ state_attr(aqara_w100, "fan_mode") }}
               - delay:
                   seconds: "{{ sync_delay }}"
-
       - conditions:
           - condition: trigger
             id:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -151,7 +151,7 @@ actions:
                   seconds: "{{ sync_delay }}"
           - if:
               - condition: template
-                value_template: >
+                value_template: >-
                   {# Define the variables#}
                   {% set source = state_attr(main_thermostat, "fan_mode") %}
                   {% set target = state_attr(aqara_w100, "fan_mode") %}
@@ -242,8 +242,7 @@ actions:
                   seconds: "{{ sync_delay }}"
           - if:
               - condition: template
-                value_template: >
-                  {{
+                value_template: >-
                   {# Define the variables#}
                   {% set source = state_attr(main_thermostat, "fan_mode") %}
                   {% set target = state_attr(aqara_w100, "fan_mode") %}
@@ -262,9 +261,11 @@ actions:
                   fan_mode: |
                     {% set source = state_attr(aqara_w100, "fan_mode") %}
                     {% set target_valid_list = state_attr(main_thermostat, "fan_modes") %}
+                    
                     {# If source is med/medium, find the target's specific medium mode #}
                     {% if source | lower == 'med' or source | lower == 'medium' %}
                       {{ target_valid_list | select('search', '(?i)^med') | first | default(source) }}
+                      
                     {# Otherwise just pass the source through #}
                     {% else %}
                       {{ source }}

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -249,7 +249,8 @@ actions:
             then:
               - action: number.set_value
                 target:
-                  entity_id: {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_temperature' }}
+                  entity_id: >-
+                    {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_temperature' }}
                 data:
                   value: |
                     {{ states(external_temperature_sensor) | float }}
@@ -262,7 +263,8 @@ actions:
             then:
               - action: number.set_value
                 target:
-                  entity_id: {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_humidity' }}
+                  entity_id: >-
+                    {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_humidity' }}
                 data:
                   value: |
                     {{ states(external_humidity_sensor) | float }}

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -6,6 +6,7 @@ blueprint:
     Optionally publishes external temperature and humidity data to the W100 display.
     Configure which HVAC modes and features your system supports.
   domain: automation
+  
   input:
     main_thermostat:
       name: Main Thermostat
@@ -75,12 +76,6 @@ blueprint:
         entity:
           domain: sensor
           device_class: humidity
-    w100_thermostat_mode:
-      name: W100 Thermostat Mode Switch
-      description: The W100 thermostat mode switch entity
-      selector:
-        entity:
-          domain: switch
 
 variables:
   main_thermostat: !input main_thermostat
@@ -93,7 +88,6 @@ variables:
   enable_external_data: !input enable_external_data
   external_temperature_sensor: !input external_temperature_sensor
   external_humidity_sensor: !input external_humidity_sensor
-  w100_thermostat_mode: !input w100_thermostat_mode
 
 triggers:
   - trigger: state
@@ -120,7 +114,8 @@ actions:
             id:
               - climate_state
           - condition: state
-            entity_id: !input w100_thermostat_mode
+            entity_id: >-
+              {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
             state:
               - "on"
         sequence:
@@ -129,13 +124,15 @@ actions:
                 value_template: >-
                   {{ states(main_thermostat) != states(aqara_w100) }}
               - condition: state
-                entity_id: !input w100_thermostat_mode
+                entity_id: >-
+                  {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
                 state:
                   - "on"
             then:
               - action: climate.set_hvac_mode
                 target:
-                  entity_id: !input aqara_w100
+                  entity_id: >-
+                    {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
                 data:
                   hvac_mode: |
                     {{ states(main_thermostat) }}
@@ -160,7 +157,8 @@ actions:
             id:
               - w100_climate_state
           - condition: state
-            entity_id: !input w100_thermostat_mode
+            entity_id: >-
+              {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
             state:
               - "on"
         sequence:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -6,6 +6,7 @@ blueprint:
     Optionally publishes external temperature and humidity data to the W100 display.
     Configure which HVAC modes and features your system supports.
   domain: automation
+  
   input:
     main_thermostat:
       name: Main Thermostat
@@ -87,7 +88,7 @@ variables:
   enable_external_data: !input enable_external_data
   external_temperature_sensor: !input external_temperature_sensor
   external_humidity_sensor: !input external_humidity_sensor
-  w100_thermostat_mode: >-
+  thermostat_mode_switch: >-
     {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
 
 triggers:
@@ -114,19 +115,17 @@ actions:
           - condition: trigger
             id:
               - climate_state
-          - condition: state
-            entity_id: !input w100_thermostat_mode
-            state:
-              - "on"
+          - condition: template
+            value_template: >-
+              {{ is_state(thermostat_mode_switch, 'on') }}
         sequence:
           - if:
               - condition: template
                 value_template: >-
                   {{ states(main_thermostat) != states(aqara_w100) }}
-              - condition: state
-                entity_id: !input w100_thermostat_mode
-                state:
-                  - "on"
+              - condition: template
+                value_template: >-
+                  {{ is_state(thermostat_mode_switch, 'on') }}
             then:
               - action: climate.set_hvac_mode
                 target:
@@ -150,14 +149,14 @@ actions:
                     {{ state_attr(main_thermostat, "temperature") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+      
       - conditions:
           - condition: trigger
             id:
               - w100_climate_state
-          - condition: state
-            entity_id: !input w100_thermostat_mode
-            state:
-              - "on"
+          - condition: template
+            value_template: >-
+              {{ is_state(thermostat_mode_switch, 'on') }}
         sequence:
           - if:
               - condition: template
@@ -229,6 +228,7 @@ actions:
                     {{ state_attr(aqara_w100, "fan_mode") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+
       - conditions:
           - condition: trigger
             id:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -149,6 +149,35 @@ actions:
                     {{ state_attr(main_thermostat, "temperature") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+          - if:
+              - condition: template
+                value_template: >
+                  {# Define the variables#}
+                  {% set source = state_attr(main_thermostat, "fan_mode") %}
+                  {% set target = state_attr(aqara_w100, "fan_mode") %}
+                  {# Normalize the source to lowercase and map med->medium for comparison #}
+                  {% set source_norm = 'medium' if source | lower == 'med' else source | lower %}
+                  {# Compare normalized values #}
+                  {{ 
+                    (source_norm != target) and 
+                    (hvac_has_vent | default(false) | bool) 
+                  }}
+            then:
+              - action: climate.set_fan_mode
+                target:
+                  entity_id: !input aqara_w100
+                data:
+                  fan_mode: |
+                    {% set source = state_attr(main_thermostat, "fan_mode") %}
+                    {# If source is med/medium, pass "medium" to the Aqara #}
+                    {% if source | lower == 'med' or source | lower == 'medium' %}
+                      medium
+                    {# Otherwise just pass the source through #}
+                    {% else %}
+                      {{ source }}
+                    {% endif %}
+              - delay:
+                  seconds: "{{ sync_delay }}"
       
       - conditions:
           - condition: trigger
@@ -215,9 +244,15 @@ actions:
               - condition: template
                 value_template: >
                   {{
-                  (state_attr(main_thermostat, "fan_mode") !=
-                  state_attr(aqara_w100, "fan_mode")) and
-                  (hvac_has_vent | default(false) | bool)
+                  {# Define the variables#}
+                  {% set source = state_attr(main_thermostat, "fan_mode") %}
+                  {% set target = state_attr(aqara_w100, "fan_mode") %}
+                  {# Normalize source to lowercase and map med->medium for comparison #}
+                  {% set source_norm = 'medium' if source | lower == 'med' else source | lower %}
+                  {# Compare normalized values #}
+                  {{ 
+                    (source_norm != target) and 
+                    (hvac_has_vent | default(false) | bool) 
                   }}
             then:
               - action: climate.set_fan_mode
@@ -225,7 +260,15 @@ actions:
                   entity_id: !input main_thermostat
                 data:
                   fan_mode: |
-                    {{ state_attr(aqara_w100, "fan_mode") }}
+                    {% set source = state_attr(aqara_w100, "fan_mode") %}
+                    {% set target_valid_list = state_attr(main_thermostat, "fan_modes") %}
+                    {# If source is med/medium, find the target's specific medium mode #}
+                    {% if source | lower == 'med' or source | lower == 'medium' %}
+                      {{ target_valid_list | select('search', '(?i)^med') | first | default(source) }}
+                    {# Otherwise just pass the source through #}
+                    {% else %}
+                      {{ source }}
+                    {% endif %}
               - delay:
                   seconds: "{{ sync_delay }}"
 

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -88,6 +88,8 @@ variables:
   enable_external_data: !input enable_external_data
   external_temperature_sensor: !input external_temperature_sensor
   external_humidity_sensor: !input external_humidity_sensor
+  thermostat_mode_switch: >-
+    {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
 
 triggers:
   - trigger: state
@@ -113,26 +115,21 @@ actions:
           - condition: trigger
             id:
               - climate_state
-          - condition: state
-            entity_id: >-
-              {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
-            state:
-              - "on"
+          - condition: template
+            value_template: >-
+              {{ is_state(thermostat_mode_switch, 'on') }}
         sequence:
           - if:
               - condition: template
                 value_template: >-
                   {{ states(main_thermostat) != states(aqara_w100) }}
-              - condition: state
-                entity_id: >-
-                  {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
-                state:
-                  - "on"
+              - condition: template
+                value_template: >-
+                  {{ is_state(thermostat_mode_switch, 'on') }}
             then:
               - action: climate.set_hvac_mode
                 target:
-                  entity_id: >-
-                    {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
+                  entity_id: !input aqara_w100
                 data:
                   hvac_mode: |
                     {{ states(main_thermostat) }}
@@ -152,15 +149,14 @@ actions:
                     {{ state_attr(main_thermostat, "temperature") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+      
       - conditions:
           - condition: trigger
             id:
               - w100_climate_state
-          - condition: state
-            entity_id: >-
-              {{ 'switch.' ~ aqara_w100.split('.')[1] ~ '_thermostat_mode' }}
-            state:
-              - "on"
+          - condition: template
+            value_template: >-
+              {{ is_state(thermostat_mode_switch, 'on') }}
         sequence:
           - if:
               - condition: template
@@ -232,6 +228,7 @@ actions:
                     {{ state_attr(aqara_w100, "fan_mode") }}
               - delay:
                   seconds: "{{ sync_delay }}"
+
       - conditions:
           - condition: trigger
             id:

--- a/w100-blueprint.yaml
+++ b/w100-blueprint.yaml
@@ -75,20 +75,6 @@ blueprint:
         entity:
           domain: sensor
           device_class: humidity
-    w100_external_temperature:
-      name: W100 External Temperature Entity
-      description: W100 external temperature number entity (optional)
-      default: []
-      selector:
-        entity:
-          domain: number
-    w100_external_humidity:
-      name: W100 External Humidity Entity
-      description: W100 external humidity number entity (optional)
-      default: []
-      selector:
-        entity:
-          domain: number
     w100_thermostat_mode:
       name: W100 Thermostat Mode Switch
       description: The W100 thermostat mode switch entity
@@ -107,8 +93,6 @@ variables:
   enable_external_data: !input enable_external_data
   external_temperature_sensor: !input external_temperature_sensor
   external_humidity_sensor: !input external_humidity_sensor
-  w100_external_temperature: !input w100_external_temperature
-  w100_external_humidity: !input w100_external_humidity
   w100_thermostat_mode: !input w100_thermostat_mode
 
 triggers:
@@ -265,10 +249,10 @@ actions:
             then:
               - action: number.set_value
                 target:
-                  entity_id: !input w100_external_temperature
+                  entity_id: {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_temperature' }}
                 data:
                   value: |
-                    {{ states(external_temperature_sensor) }}
+                    {{ states(external_temperature_sensor) | float }}
               - delay:
                   seconds: "{{ sync_delay }}"
           - if:
@@ -278,10 +262,10 @@ actions:
             then:
               - action: number.set_value
                 target:
-                  entity_id: !input w100_external_humidity
+                  entity_id: {{ 'number.' ~ aqara_w100.split('.')[1] ~ '_external_humidity' }}
                 data:
                   value: |
-                    {{ states(external_humidity_sensor) }}
+                    {{ states(external_humidity_sensor) | float }}
               - delay:
                   seconds: "{{ sync_delay }}"
 


### PR DESCRIPTION
Key changes
- Removed manual inputs
w100_external_temperature, w100_external_humidity, and w100_thermostat_mode are no longer user-selected.
- Dynamic entity derivation
External temperature, humidity, and thermostat-mode switch entities are now automatically generated from the selected aqara_w100 (e.g., climate.temp_hum_office → number.temp_hum_office_external_temperature, etc.).
- Simplified and more robust blueprint
Fewer inputs, fewer configuration errors, and more consistent behavior across all sync paths.